### PR TITLE
Update to new Perl syntax

### DIFF
--- a/smallblog.pl
+++ b/smallblog.pl
@@ -116,7 +116,7 @@ foreach my $post (@posts) {
 }
 
 # Generate tags/$tag.html
-foreach my $tag (keys $site->{tags}) {
+foreach my $tag (keys %{ $site->{tags} }) {
 	my @tag_posts = map {grep(/$tag/, @{$_->{tags}}) ? $_ : ()} @posts;
 
 	my $vars = {


### PR DESCRIPTION
Experimental keys on scalar is now forbidden at ../../smallblog.pl line 119.
Type of arg 1 to keys must be hash or array (not hash element) at ../../smallblog.pl line 119, near "}) "
Execution of ../../smallblog.pl aborted due to compilation errors.